### PR TITLE
support for controlPin, improved example

### DIFF
--- a/ModbusRTUSlave.h
+++ b/ModbusRTUSlave.h
@@ -25,15 +25,18 @@ class ModbusRTUSlaveBitAddress
 class ModbusRTUSlave
 {
 	public : 
-		ModbusRTUSlave(byte Slave, HardwareSerial *ser);
+		ModbusRTUSlave(byte slaveId, HardwareSerial *ser, u8 conrolPinNumber);
 		void begin(int baudrate);
 		boolean addWordArea(u16 Address, u16* values, int cnt);
 		boolean addBitArea(u16 Address, u8* values, int cnt);
 		void process();
 
 	private:
-		byte slave;
-		HardwareSerial *ser;
+		byte const slave;
+		HardwareSerial * const ser;
+		u8 const controlPin;
+		bool isReading;
+
 		LinkedList<ModbusRTUSlaveWordAddress*>  *words;
 		LinkedList<ModbusRTUSlaveBitAddress*>  *bits;
 		ModbusRTUSlaveWordAddress* getWordAddress(u16 Addr);
@@ -44,6 +47,11 @@ class ModbusRTUSlave
 		int ResCnt=0;
 		unsigned long lastrecv;
 		void getCRC(byte* pby, int arsize, int startindex, int nSize, byte* byFirstReturn, byte* bySecondReturn);
+
+		void switchToReadingIfNotReadingNow();
+		bool isDataAvail();
+		int doRead();
+		void doWrite(byte*, int);
 };
 
 const byte auchCRCHi[] = {

--- a/examples/SimpleModbus/SimpleModbus.ino
+++ b/examples/SimpleModbus/SimpleModbus.ino
@@ -1,21 +1,32 @@
 #include <ModbusRTUSlave.h>
 
-u16 _D[100];
-u8 _M[50];
+// size of data which will be read and written
+#define DATA_SIZE 100
+// data array which will be read and written
+u16 _D[DATA_SIZE];
 
-ModbusRTUSlave rtu(1, &Serial1);
+// address (kind of name) of above data, may be anything
+#define VIRTUAL_ADDRESS 0x7000
 
-void setup() {
-  pinMode(3, OUTPUT);
-  pinMode(4, OUTPUT);
-  
-  rtu.addWordArea(0x7000, _D, 100);
-  rtu.addBitArea(0x1000, _M, 50);
+#define OUR_ID_AS_A_SLAVE 101
+#define PIN_CONNECTED_TO_BOTH_DE_AND_RE 3
+
+ModbusRTUSlave rtu(OUR_ID_AS_A_SLAVE, &Serial1, PIN_CONNECTED_TO_BOTH_DE_AND_RE);
+
+void setup()
+{ 
+  rtu.addWordArea(VIRTUAL_ADDRESS, _D, DATA_SIZE);
   rtu.begin(9600);
+
+  //Serial.begin(9600); // not needed, for logging purpose only
+
+  // set some value in data array to test if master can read and modify it
+  _D[0] = 160;
 }
 
-void loop() {
+void loop()
+{
+  // waiting for requests from master
+  // reading and writing _D according to requests from master happens here
   rtu.process();
-  digitalWrite(3, getBit(_M,0));
-  digitalWrite(4, getBit(_M,1));
 }


### PR DESCRIPTION
Added support for controlling RE DE pins (lined together and connected by one wire to some pin of arduino) from UART to RS485 converter (like this one:  [](https://probots.co.in/index.php?main_page=product_info&products_id=865)).

Also improved example code by explanation comments.